### PR TITLE
Added Facebook SDK to track installs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,4 +16,5 @@ dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'io.branch.sdk.android:library:1.+'
     compile 'com.google.android.gms:play-services:6.5.87'
+    compile 'com.facebook.android:facebook-android-sdk:[4,5)'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,6 +66,9 @@
         <meta-data android:name="io.branch.sdk.BranchKey" android:value="@string/branch_key" />
         <meta-data android:name="io.branch.sdk.BranchKey.test" android:value="@string/branch_key_test" />
 
+
+        <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/io/branch/branchster/SplashActivity.java
+++ b/app/src/main/java/io/branch/branchster/SplashActivity.java
@@ -16,6 +16,9 @@ import io.branch.referral.Branch;
 import io.branch.referral.BranchError;
 import io.branch.referral.util.LinkProperties;
 
+import com.facebook.FacebookSdk;
+import com.facebook.appevents.AppEventsLogger;
+
 public class SplashActivity extends Activity {
 
     TextView txtLoading;
@@ -27,6 +30,10 @@ public class SplashActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        FacebookSdk.sdkInitialize(getApplicationContext());
+        AppEventsLogger.activateApp(getApplicationContext());
+
         setContentView(R.layout.activity_splash);
 
         mContext = this;

--- a/app/src/main/res/values/api_keys.xml
+++ b/app/src/main/res/values/api_keys.xml
@@ -9,12 +9,6 @@
     <string name="branch_key">key_live_gchnKkd3l3m9YBPP2d73jmfejkcgVjgM</string>
     <string name="branch_key_test">key_test_lkhEVOq9sPU9FXgbSAoQthfhqsd5EVaV</string>
 
-    <!--
-    Your Your Facebook App ID Goes Here
-    If you don't have one, see the Facebook SDK for Android documentation:
-    https://developers.facebook.com/docs/android
-    -->
-    <string name="facebook_app_id">288726397999326</string>
 
     <!--
     Your Twitter Key and Secret Goes Here

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     
     <color name="white">#FFFFFF</color>
 
+    <string name="facebook_app_id">288726397999326</string>
+
     <!-- Defaults -->
     <string name="monster_name">Bingles Jingleheimer</string>
 


### PR DESCRIPTION
I want to confirm our install ads are working 100% and need the Facebook SDK to validate our numbers.

@sojanpr Can you release this to the app store asap? Thanks!